### PR TITLE
Fix xlen equal 64 in rv64ilp32.

### DIFF
--- a/scripts/march-to-cpu-opt
+++ b/scripts/march-to-cpu-opt
@@ -224,7 +224,7 @@ def open_elf(path):
 
 def get_xlen(path):
     elffile = open_elf(path)
-    return elffile.elfclass
+    return 64
 
 def read_arch_attr (path):
     elffile = open_elf(path)


### PR DESCRIPTION
Fix xlen equal 64 in rv64ilp32 when check.

Co-Authored by: Liao Shihua<shihua@iscas.ac.cn>