### PR TITLE
add support for rv64ilp32 GCC regression testing and update QEMU submodule to f946be9 commit

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,7 +73,7 @@ jobs:
           sudo mkdir -p /opt/riscv/qemu-linux/
           sudo cp -v demo /opt/riscv/qemu-linux/
           # Test the demo
-          qemu-riscv64 /opt/riscv/qemu-linux/demo
+          qemu-riscv64ilp32 /opt/riscv/qemu-linux/demo
           # Copy demo code
           sudo cp -v qemu-linux/hello_world.c /opt/riscv/qemu-linux/
 

--- a/configure
+++ b/configure
@@ -3880,10 +3880,10 @@ fi
 
 
 if test "x$enable_qemu_system" != xno; then :
-  qemu_targets=riscv64-linux-user,riscv32-linux-user,riscv64-softmmu,riscv32-softmmu
+  qemu_targets=riscv64-linux-user,riscv32-linux-user,riscv64-softmmu,riscv32-softmmu,riscv64ilp32-linux-user,riscv64ilp32-softmmu
 
 else
-  qemu_targets=riscv64-linux-user,riscv32-linux-user
+  qemu_targets=riscv64-linux-user,riscv32-linux-user,riscv64ilp32-linux-user
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -315,7 +315,7 @@ AC_ARG_ENABLE(qemu_system,
 	)
 
 AS_IF([test "x$enable_qemu_system" != xno],
-	[AC_SUBST(qemu_targets, [riscv64-linux-user,riscv32-linux-user,riscv64-softmmu,riscv32-softmmu])],
-	[AC_SUBST(qemu_targets, [riscv64-linux-user,riscv32-linux-user])])
+        [AC_SUBST(qemu_targets, [riscv64-linux-user,riscv64ilp32-linux-user,riscv32-linux-user,riscv64-softmmu,riscv64ilp32-softmmu,riscv32-softmmu])],
+	[AC_SUBST(qemu_targets, [riscv64-linux-user,riscv32-linux-user,riscv64ilp32-linux-user])])
 
 AC_OUTPUT

--- a/scripts/march-to-cpu-opt
+++ b/scripts/march-to-cpu-opt
@@ -45,6 +45,12 @@ CPU_OPTIONS = {
   "extensions":      [],
 }
 
+ELF_HEADER = {
+  "e_flags":         "",
+}
+
+EF_RISCV_X32 =  0x0020
+
 SUPPORTTED_EXTS = "iemafdcbvph"
 MC_EXT_PREFIX = "zsx"
 
@@ -159,7 +165,10 @@ def get_elen(ext_dict, xlen):
 
 def print_qemu_cpu():
     cpu_options = []
-    cpu_options.append("rv{0}".format(CPU_OPTIONS['xlen']))
+    if ELF_HEADER["e_flags"] & EF_RISCV_X32 != 0:
+        cpu_options.append("rv{0}".format(64))
+    else:
+        cpu_options.append("rv{0}".format(CPU_OPTIONS['xlen']))
 
     if CPU_OPTIONS['vlen']:
         cpu_options.append("vlen={0}".format(CPU_OPTIONS['vlen']))
@@ -218,13 +227,14 @@ def selftest():
 def open_elf(path):
     try:
         elffile = elftools.elf.elffile.ELFFile(open(path, 'rb'))
+        ELF_HEADER["e_flags"] = elffile.header["e_flags"]
     except elftools.common.exceptions.ELFError:
         raise Exception("%s is not ELF file!" % path)
     return elffile
 
 def get_xlen(path):
     elffile = open_elf(path)
-    return 64
+    return elffile.elfclass
 
 def read_arch_attr (path):
     elffile = open_elf(path)

--- a/scripts/wrapper/qemu/riscv64-unknown-linux-gnu-run
+++ b/scripts/wrapper/qemu/riscv64-unknown-linux-gnu-run
@@ -13,5 +13,10 @@ done
 xlen="$(march-to-cpu-opt --elf-file-path $1 --print-xlen)"
 qemu_cpu="$(march-to-cpu-opt --elf-file-path $1 --print-qemu-cpu)"
 
-QEMU_CPU="${qemu_cpu}" qemu-riscv${xlen} -r 5.10 "${qemu_args[@]}" \
+if [ "$xlen" = "32" ] && [ "$qemu_cpu" = "rv64" ]; then
+    QEMU_CPU="${qemu_cpu}" qemu-riscv64ilp${xlen} -r 5.10 "${qemu_args[@]}" \
   -L ${RISC_V_SYSROOT} "$@"
+else
+    QEMU_CPU="${qemu_cpu}" qemu-riscv${xlen} -r 5.10 "${qemu_args[@]}" \
+  -L ${RISC_V_SYSROOT} "$@"
+fi


### PR DESCRIPTION
This commit adds support for GCC regression testing of the rv64ilp32 target and updates QEMU submodule to [f946be9](https://github.com/ruyisdk/qemu/commit/f946be99cb99c185923e18bee206ecd0c59ba117) commit.

The changes include:

- Add riscv64ilp32-linux-user and riscv64ilp32-softmmu targets in configure and configure.ac.
- Update march-to-cpu-opt script to detect rv64ilp32 target based on the ELF header flags and set the appropriate QEMU CPU model.
- Update riscv64-unknown-linux-gnu-run wrapper script to use qemu-riscv64ilp32 for rv64ilp32 executables.

With these changes, the GCC regression testing framework can properly test the rv64ilp32 target and ILP32D ABI on 64-bit RISC-V systems.

Testing:

This change has been tested with the following commands:

$ ./configure --with-arch=rv64gc --with-abi=ilp32d --prefix=path

$ make check-gcc RUNTESTFLAGS='--target_board=riscv-sim' -j$(nproc)

Signed-off-by: Kaiyao Duan <inspiremenow@murena.io>