### PR TITLE
CI/CD: Change nightly-release toolchain-name from riscv64ilp32 to ris…

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -86,7 +86,7 @@ jobs:
             *)
               MODE="elf";;
           esac
-          echo "TOOLCHAIN_NAME=riscv$BITS-$MODE-${{ matrix.os }}-${{ matrix.compiler }}-nightly" >> $GITHUB_OUTPUT
+          echo "TOOLCHAIN_NAME=riscv64-$MODE-${{ matrix.os }}-${{ matrix.compiler }}-nightly" >> $GITHUB_OUTPUT
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
…cv64

We had changed the toolchain-name form riscv64ilp32 to riscv64 in build.yaml, but forget it in nightly-release.yaml.
Please create a new release version after merge this pr.